### PR TITLE
Add support for multiple loading indicators

### DIFF
--- a/docs/guide/js/guide.js
+++ b/docs/guide/js/guide.js
@@ -51,10 +51,13 @@
 });
 
   setInterval(function() {
-    $('.loading-bullet')
-      .velocity('transition.slideRightIn', { stagger: 250 })
-      .delay(750)
-      .velocity({ opacity: 0 }, 500);
+    var indicators = $('.loading-indicator:visible');
+    for (var i = 0; i < indicators.length; i++) {
+      $(indicators[i]).find('.loading-bullet')
+        .velocity('transition.slideRightIn', { stagger: 250 })
+        .delay(750)
+        .velocity({ opacity: 0 }, 500);
+    }
   }, 2000);
 
   // Twitter Typeahead

--- a/docs/guide/js/guide.js
+++ b/docs/guide/js/guide.js
@@ -51,7 +51,7 @@
 });
 
   setInterval(function() {
-    var indicators = $('.loading-indicator:visible');
+    var indicators = $('.loading-indicator');
     for (var i = 0; i < indicators.length; i++) {
       $(indicators[i]).find('.loading-bullet')
         .velocity('transition.slideRightIn', { stagger: 250 })


### PR DESCRIPTION
The logic used in the docs for the loading indicators doesn't work well if you have many indicators on a page (for instance, if you use one while different templates are loaded asynchronously). In that case, all the bullets are animated as one giant group, instead of independently. This minor change will fix that.