### PR TITLE
added class to handle top level panel with no border 

### DIFF
--- a/dist/css/availity-uikit.css
+++ b/dist/css/availity-uikit.css
@@ -6335,10 +6335,6 @@ a.list-group-item-danger.active:focus {
   border-radius: 2px;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
 }
-.panel-borderless {
-  margin-bottom: 20px;
-  background-color: #ffffff;
-}
 .panel-body {
   padding: 15px;
 }

--- a/dist/css/availity-uikit.css
+++ b/dist/css/availity-uikit.css
@@ -1,6 +1,6 @@
 /**
  * availity-uikit v0.7.1 -- May-12
- * Copyright 2015 Availity, LLC 
+ * Copyright 2015 Availity, LLC
  */
 
 @font-face {
@@ -6335,6 +6335,10 @@ a.list-group-item-danger.active:focus {
   border-radius: 2px;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
 }
+.panel-borderless {
+  margin-bottom: 20px;
+  background-color: #ffffff;
+}
 .panel-body {
   padding: 15px;
 }
@@ -7591,7 +7595,7 @@ button.close {
 /*!
  * Yamm!3
  * Yet another megamenu for Bootstrap 3
- * 
+ *
  * http://geedmo.github.com/yamm3
  */
 .yamm .nav,

--- a/less/availity-panel-component.html
+++ b/less/availity-panel-component.html
@@ -90,6 +90,18 @@ usage: |
   </div>
 </code>
 
+<h3 class="guide-subsection-title">Borderless Panel</h3>
+<div class="guide-example">
+  <div class="panel-borderless">
+    Borderless panel example
+  </div>
+</div>
+<code class="language-markup">
+  <div class="panel-borderless">
+    Basic panel example
+  </div>
+</code>
+
 <h3 class="guide-subsection-title">Contextual classes</h3>
 <div class="guide-example">
   <div class="panel panel-primary">

--- a/less/availity-panel.less
+++ b/less/availity-panel.less
@@ -212,6 +212,6 @@
 }
 
 .panel-borderless {
-  margin-bottom: 20px;
+  margin-bottom: (@availity-panel-bottom-margin);
   background-color: #ffffff;
 }

--- a/less/availity-panel.less
+++ b/less/availity-panel.less
@@ -210,3 +210,8 @@
     padding: .3em;
   }
 }
+
+.panel-borderless {
+  margin-bottom: 20px;
+  background-color: #ffffff;
+}

--- a/less/availity-variables.less
+++ b/less/availity-variables.less
@@ -301,6 +301,7 @@
 
 @availity-panel-card-padding: 24px;
 @availity-panel-collapse-border: 1px solid @gray-lightest;
+@availity-panel-bottom-margin: 20px;
 
 // Tables
 @availity-table-border-color: #dddddd;


### PR DESCRIPTION
The .panel-borderless class is needed to handled a top level panel that will be served into an iframe.  Within the working project, the panel is the top level div and is unaware of the iframe within which it will reside.  The border for the .panel was requested removed by UX.