### PR TITLE
fixing typo and example placeholder

### DIFF
--- a/less/availity-form-component.html
+++ b/less/availity-form-component.html
@@ -16,11 +16,11 @@ notes: |
   instance, should be smaller than a street address field, as one is known
   to be 5 characters while the other could be much longer.
 ---
-<h3 class="guide-subsection-title">Label <small>with placholder text</small></h3>
+<h3 class="guide-subsection-title">Label <small>with placeholder text</small></h3>
 <div class="guide-example">
   <div class="form-group">
     <label for="text1">State</label>
-    <input type="text" class="form-control" id="text1" placeholder="">
+    <input type="text" class="form-control" id="text1" placeholder="Enter a State">
   </div>
 </div>
 <code class="language-markup">


### PR DESCRIPTION
* Typo "placholder" should be "placeholder"
* Example didn't actually demonstrate a placeholder