### PR TITLE
fix to align icon in headers

### DIFF
--- a/less/availity-app-icons-component.html
+++ b/less/availity-app-icons-component.html
@@ -103,3 +103,59 @@ title: App Icons
     <span class="app-icon app-icon-xl app-icon-branded-orange">ai<span class="caret"></span></span>
   </div>
 </code>
+
+<h3 class="guide-subsection-title">With Title</h3>
+<div class="guide-example">
+  <div>
+    <h1>
+      <span class="app-icon app-icon-black">ai</span>
+      <span class="app-icon-title">h1. Application Title</span>
+    </h1>
+    <h2>
+      <span class="app-icon app-icon-blue">ai</span>
+      <span class="app-icon-title">h2. Application Title</span>
+    </h2>
+    <h3>
+      <span class="app-icon app-icon-green">ai</span>
+      <span class="app-icon-title">h3. Application Title</span>
+    </h3>
+    <h4>
+      <span class="app-icon app-icon-neon">ai</span>
+      <span class="app-icon-title">h4. Application Title</span>
+    </h4>
+    <h5>
+      <span class="app-icon app-icon-orange">ai</span>
+      <span class="app-icon-title">h5. Application Title</span>
+    </h5>
+    <h6>
+      <span class="app-icon app-icon-branded-black">ai<span class="caret"></span></span>
+      <span class="app-icon-title">h6. Application Title</span>
+    </h6>
+  </div>
+</div>
+<code class="language-markup">
+  <h1>
+    <span class="app-icon app-icon-black">ai</span>
+    <span class="app-icon-title">h1. Application Title</span>
+  </h1>
+  <h2>
+    <span class="app-icon app-icon-blue">ai</span>
+    <span class="app-icon-title">h2. Application Title</span>
+  </h2>
+  <h3>
+    <span class="app-icon app-icon-green">ai</span>
+    <span class="app-icon-title">h3. Application Title</span>
+  </h3>
+  <h4>
+    <span class="app-icon app-icon-neon">ai</span>
+    <span class="app-icon-title">h4. Application Title</span>
+  </h4>
+  <h5>
+    <span class="app-icon app-icon-orange">ai</span>
+    <span class="app-icon-title">h5. Application Title</span>
+  </h5>
+  <h6>
+    <span class="app-icon app-icon-branded-black">ai<span class="caret"></span></span>
+    <span class="app-icon-title">h6. Application Title</span>
+  </h6>
+</code>

--- a/less/availity-app-icons.less
+++ b/less/availity-app-icons.less
@@ -33,13 +33,6 @@
   );
 }
 
-h1{
-  > .app-icon{
-    margin-top: -18px;
-    margin-right: 20px;
-  }
-}
-
 // app icons
 .app-icon {
   position: relative;
@@ -126,6 +119,11 @@ h1{
     border-color: transparent @availity-app-icon-branded-orange-caret-color transparent transparent;
   }
 }
+
+.app-icon-title {
+  vertical-align: middle;
+}
+
 .dropdown-menu {
   > li.app-menu-item {
     padding: .4em 0;

--- a/less/availity-app-icons.less
+++ b/less/availity-app-icons.less
@@ -33,6 +33,13 @@
   );
 }
 
+h1{
+  > .app-icon{
+    margin-top: -18px;
+    margin-right: 20px;
+  }
+}
+
 // app icons
 .app-icon {
   position: relative;


### PR DESCRIPTION
Heya,

So new PDM design has icon and header in the same line, but it doesn't line up cleanly right now. I talked with @taylornturner and she suggested this.

Here's the mark up
```html
<h1>
  <span class="app-icon app-icon-blue">PDM</span>Manage Business
</h1>
```

## Before the change
![iconinheaderbefore](https://cloud.githubusercontent.com/assets/697955/8235508/017432c2-15a8-11e5-8791-1a7c33d9c439.PNG)



## After
![iconinheaderafter](https://cloud.githubusercontent.com/assets/697955/8235502/fb817c30-15a7-11e5-851c-4a72a3db69cf.PNG)
