### PR TITLE
Fix/href on wizard

### DIFF
--- a/less/availity-wizard-component.html
+++ b/less/availity-wizard-component.html
@@ -32,20 +32,20 @@ title: Wizard
 <code class="language-markup">
 <div class="stepwizard">
   <div class="stepwizard-row">
-    <a class="stepwizard-step complete">
-      <span href="#step-1" class="stepwizard-badge">1</span>
+    <a class="stepwizard-step complete" href="#step-1">
+      <span class="stepwizard-badge">1</span>
       <span class="stepwizard-title">First</span>
     </a>
-    <a class="stepwizard-step active">
-      <span href="#step-2" class="stepwizard-badge">2</span>
+    <a class="stepwizard-step active" href="#step-2">
+      <span class="stepwizard-badge">2</span>
       <span class="stepwizard-title">Second with some long text</span>
     </a>
-    <a class="stepwizard-step">
-      <span href="#step-3" class="stepwizard-badge">3</span>
+    <a class="stepwizard-step" href="#step-3">
+      <span class="stepwizard-badge">3</span>
       <span class="stepwizard-title">Third</span>
     </a>
-    <a class="stepwizard-step disabled">
-      <span href="#step-3" class="stepwizard-badge">4</span>
+    <a class="stepwizard-step disabled" href="#step-4">
+      <span class="stepwizard-badge">4</span>
       <span class="stepwizard-title">Fourth with some really really really long text</span>
     </a>
   </div>
@@ -56,20 +56,20 @@ title: Wizard
 <div class="guide-example">
   <div class="stepwizard stepwizard-stacked">
     <div class="stepwizard-row">
-      <a class="stepwizard-step complete">
-        <span href="#step-1" class="stepwizard-badge">1</span>
+      <a class="stepwizard-step complete" href="#step-1">
+        <span class="stepwizard-badge">1</span>
         <span class="stepwizard-title">First</span>
       </a>
-      <a class="stepwizard-step active">
-        <span href="#step-2" class="stepwizard-badge">2</span>
+      <a class="stepwizard-step active" href="#step-2">
+        <span class="stepwizard-badge">2</span>
         <span class="stepwizard-title">Second with some long text</span>
       </a>
-      <a class="stepwizard-step">
-        <span href="#step-3" class="stepwizard-badge">3</span>
+      <a class="stepwizard-step" href="#step-3">
+        <span class="stepwizard-badge">3</span>
         <span class="stepwizard-title">Third</span>
       </a>
-      <a class="stepwizard-step disabled">
-        <span href="#step-3" class="stepwizard-badge">4</span>
+      <a class="stepwizard-step disabled" href="#step-4">
+        <span class="stepwizard-badge">4</span>
         <span class="stepwizard-title">Fourth with longest text ever written in a wizard</span>
       </a>
     </div>
@@ -78,20 +78,20 @@ title: Wizard
 <code class="language-markup">
 <div class="stepwizard stepwizard-stacked">
   <div class="stepwizard-row">
-    <a class="stepwizard-step complete">
-      <span href="#step-1" class="stepwizard-badge"></span>
+    <a class="stepwizard-step complete" href="#step-1">
+      <span class="stepwizard-badge"></span>
       <span class="stepwizard-title">First (Complete)</span>
     </a>
-    <a class="stepwizard-step active">
-      <span href="#step-2" class="stepwizard-badge">2</span>
+    <a class="stepwizard-step active" href="#step-2">
+      <span class="stepwizard-badge">2</span>
       <span class="stepwizard-title">Second with some long text (Active)</span>
     </a>
-    <a class="stepwizard-step">
-      <span href="#step-3" class="stepwizard-badge">3</span>
+    <a class="stepwizard-step" href="#step-3">
+      <span class="stepwizard-badge">3</span>
       <span class="stepwizard-title">Third</span>
     </a>
-    <a class="stepwizard-step disabled">
-      <span href="#step-3" class="stepwizard-badge">4</span>
+    <a class="stepwizard-step disabled" href="#step-4">
+      <span class="stepwizard-badge">4</span>
       <span class="stepwizard-title">Fourth with longest text ever written in a wizard (Disabled)</span>
     </a>
   </div>
@@ -101,24 +101,24 @@ title: Wizard
   <div class="guide-example">
     <div class="stepwizard stepwizard-progress">
       <div class="stepwizard-row">
-        <a class="stepwizard-step complete">
-          <span href="#step-1" class="stepwizard-badge"></span>
+        <a class="stepwizard-step complete" href="#step-1">
+          <span class="stepwizard-badge"></span>
           <span class="stepwizard-title">First</span>
           <p>(Complete)</p>
         </a>
-        <a class="stepwizard-step active">
-          <span href="#step-2" class="stepwizard-badge"></span>
+        <a class="stepwizard-step active" href="#step-2">
+          <span class="stepwizard-badge"></span>
           <span class="stepwizard-title">
             <span>Second with some long text</span>
             <p>(Active)</p>
           </span>
         </a>
-        <a class="stepwizard-step">
-          <span href="#step-3" class="stepwizard-badge"></span>
+        <a class="stepwizard-step" href="#step-3">
+          <span class="stepwizard-badge"></span>
           <span class="stepwizard-title">Third</span>
         </a>
-        <a class="stepwizard-step disabled">
-          <span href="#step-3" class="stepwizard-badge"></span>
+        <a class="stepwizard-step disabled" href="#step-4">
+          <span class="stepwizard-badge"></span>
           <span class="stepwizard-title">Fourth with some really really really long text</span>
           <p>(Disabled)</p>
         </a>
@@ -128,20 +128,20 @@ title: Wizard
 <code class="language-markup">
 <div class="stepwizard stepwizard-progress">
   <div class="stepwizard-row">
-    <a class="stepwizard-step complete">
-      <span href="#step-1" class="stepwizard-badge"></span>
+    <a class="stepwizard-step complete" href="#step-1">
+      <span class="stepwizard-badge"></span>
       <span class="stepwizard-title">First</span>
     </a>
-    <a class="stepwizard-step active">
-      <span href="#step-2" class="stepwizard-badge"></span>
+    <a class="stepwizard-step active" href="#step-2">
+      <span class="stepwizard-badge"></span>
       <span class="stepwizard-title">Second with some long text</span>
     </a>
-    <a class="stepwizard-step">
-      <span href="#step-3" class="stepwizard-badge"></span>
+    <a class="stepwizard-step" href="#step-3">
+      <span class="stepwizard-badge"></span>
       <span class="stepwizard-title">Third</span>
     </a>
-    <a class="stepwizard-step disabled">
-      <span href="#step-3" class="stepwizard-badge"></span>
+    <a class="stepwizard-step disabled" href="#step-4">
+      <span class="stepwizard-badge"></span>
       <span class="stepwizard-title">Fourth with some really really really long text</span>
     </a>
   </div>
@@ -152,20 +152,20 @@ title: Wizard
   <div class="guide-example">
     <div class="stepwizard stepwizard-progress stepwizard-stacked">
       <div class="stepwizard-row">
-        <a class="stepwizard-step complete">
+        <a class="stepwizard-step complete" href="#step-1">
           <span href="#step-1" class="stepwizard-badge"></span>
           <span class="stepwizard-title">Complete</span>
         </a>
-        <a class="stepwizard-step active">
-          <span href="#step-2" class="stepwizard-badge"></span>
+        <a class="stepwizard-step active"  href="#step-2">
+          <span class="stepwizard-badge"></span>
           <span class="stepwizard-title">Active</span>
         </a>
-        <a class="stepwizard-step">
-          <span href="#step-3" class="stepwizard-badge"></span>
+        <a class="stepwizard-step" href="#step-3">
+          <span class="stepwizard-badge"></span>
           <span class="stepwizard-title">Normal</span>
         </a>
-        <a class="stepwizard-step disabled">
-          <span href="#step-3" class="stepwizard-badge"></span>
+        <a class="stepwizard-step disabled" href="#step-4">
+          <span class="stepwizard-badge"></span>
           <span class="stepwizard-title">Disabled</span>
         </a>
       </div>
@@ -174,20 +174,20 @@ title: Wizard
 <code class="language-markup">
 <div class="stepwizard stepwizard-progress stepwizard-stacked">
   <div class="stepwizard-row">
-    <a class="stepwizard-step complete">
-      <span href="#step-1" class="stepwizard-badge"></span>
+    <a class="stepwizard-step complete" href="#step-1">
+      <span class="stepwizard-badge"></span>
       <span class="stepwizard-title">Complete</span>
     </a>
-    <a class="stepwizard-step active">
-      <span href="#step-2" class="stepwizard-badge"></span>
+    <a class="stepwizard-step active" href="#step-2">
+      <span class="stepwizard-badge"></span>
       <span class="stepwizard-title">Active</span>
     </a>
-    <a class="stepwizard-step">
-      <span href="#step-3" class="stepwizard-badge"></span>
+    <a class="stepwizard-step" href="#step-3">
+      <span class="stepwizard-badge"></span>
       <span class="stepwizard-title">Normal</span>
     </a>
-    <a class="stepwizard-step disabled">
-      <span href="#step-3" class="stepwizard-badge"></span>
+    <a class="stepwizard-step disabled" href="#step-4">
+      <span class="stepwizard-badge"></span>
       <span class="stepwizard-title">Disabled</span>
     </a>
   </div>

--- a/less/availity-wizard.less
+++ b/less/availity-wizard.less
@@ -26,7 +26,6 @@
 
 .stepwizard-title {
   display: block;
-
 }
 
 .stepwizard-step {

--- a/less/availity-wizard.less
+++ b/less/availity-wizard.less
@@ -2,6 +2,9 @@
   display: table;
   width: 100%;
   position: relative;
+  a{
+    text-decoration: none;
+  }
 }
 
 .stepwizard-row {
@@ -23,6 +26,7 @@
 
 .stepwizard-title {
   display: block;
+
 }
 
 .stepwizard-step {
@@ -34,7 +38,6 @@
   padding: @nav-link-padding;
 
   &:hover {
-    text-decoration: none;
     background-color: @gray-lightest;
   }
 

--- a/less/availity-wizard.less
+++ b/less/availity-wizard.less
@@ -2,7 +2,7 @@
   display: table;
   width: 100%;
   position: relative;
-  a{
+  a {
     text-decoration: none;
   }
 }


### PR DESCRIPTION
So we had hrefs on the spans and not the anchors in the documentation.

The anchors had text-decoration if the had the href.

Here's the issue before the css fix.
![whyyyyy](https://cloud.githubusercontent.com/assets/697955/8238147/7d764110-15b9-11e5-8bc6-9edf0dfa79c6.png)

So this updates the documentation and fixes that text decoration.