### PR TITLE
Hotfix/billboard sizing

### DIFF
--- a/less/availity-spaces.less
+++ b/less/availity-spaces.less
@@ -1,6 +1,14 @@
+.billboard {
+  min-height: 260px;
+  background-size:cover;
+  background-position:top right;
+  background-repeat: no-repeat;
+}
+
 .billboard-featured {
   padding: @availity-panel-card-padding;
   font-size: @font-size-medium;
+  min-height: 260px;
 }
 
 .spaces-header {
@@ -12,6 +20,7 @@
   width: 234px;
   height: 60px;
   display: inline-block;
+  background-repeat: no-repeat;
 }
 
 .spaces-link {

--- a/less/payers/availity-florida-blue.less
+++ b/less/payers/availity-florida-blue.less
@@ -7,7 +7,7 @@
   }
 
   .billboard {
-    background: url("../images/billboard-florida-blue.png") no-repeat center center;
+    background-image: url("../images/billboard-florida-blue.png");
     background-color: white;
     color: @white;
   }


### PR DESCRIPTION
Fixed issue where if featured app was missing or featured app + content was not 260px high the billboard shrunk. Also fixed issue where billboard background image did not resize correctly if featured app size grew above 260px