### PR TITLE
add 600 font-weight to headers.

### DIFF
--- a/less/availity-type.less
+++ b/less/availity-type.less
@@ -3,7 +3,7 @@
 
 h1, h2, h3, h4, h5, h6,
 .h1, .h2, .h3, .h4, .h5, .h6 {
-
+  font-weight: 600;
   &.subheader {
     color: @text-lighter;
   }


### PR DESCRIPTION
So Arial has a major difference between 500 and 600. Helvetica... not so much.
Here's how this change affects arial font. I'm not running a mac to check the helvetica changes. The heavier weight follows the designs I'm getting. 

# before

![500weight](https://cloud.githubusercontent.com/assets/697955/8482057/a57522c8-20ac-11e5-903c-b9712dc44181.PNG)

# after

![600weight](https://cloud.githubusercontent.com/assets/697955/8482055/a365e6fc-20ac-11e5-8428-7768c7546643.PNG)