### PR TITLE
IE table headers not bold

### DIFF
--- a/less/availity-tables.less
+++ b/less/availity-tables.less
@@ -1,3 +1,7 @@
+.table > thead {
+  font-weight: bold;
+}
+
 .table > thead > tr > th {
   border-width: 1px;
 }

--- a/less/availity-tables.less
+++ b/less/availity-tables.less
@@ -1,9 +1,6 @@
-.table > thead {
-  font-weight: bold;
-}
-
 .table > thead > tr > th {
   border-width: 1px;
+  font-weight: bold;
 }
 
 .table > tbody > tr > td {


### PR DESCRIPTION
Apparently other browsers do this?

Anyways, this forces consistency cross browsers.

This makes makes sure all `th` are bold.