### PR TITLE
labels are now vertically-aligned middle

### DIFF
--- a/less/availity-labels.less
+++ b/less/availity-labels.less
@@ -66,6 +66,7 @@ h6, .h6 {
 .label-remove {
 
   display: inline-block; // https://github.com/twbs/bootstrap/issues/13219
+  vertical-align: middle;
 
   a {
     color: inherit;


### PR DESCRIPTION
removable labels were not vertically aligned to the middle of other controls

Before:
![image](https://cloud.githubusercontent.com/assets/902065/9433832/a464c258-4a05-11e5-9d58-843bb2565626.png)

After:
![image](https://cloud.githubusercontent.com/assets/902065/9433839/b4773914-4a05-11e5-82b2-93df34884716.png)

