### PR TITLE
Change CSS on card-warning / card-inverse combination for contrast

### DIFF
--- a/less/availity-cards-component.html
+++ b/less/availity-cards-component.html
@@ -306,7 +306,7 @@ description: |
 <div class="card card-inverse card-primary text-center">
   <div class="card-block">
     <blockquote class="card-blockquote">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. <a class="card-link">Integer</a> posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
     </blockquote>
   </div>
@@ -314,7 +314,7 @@ description: |
 <div class="card card-inverse card-success text-center">
   <div class="card-block">
     <blockquote class="card-blockquote">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. <a class="card-link">Integer</a> posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
     </blockquote>
   </div>
@@ -322,7 +322,7 @@ description: |
 <div class="card card-inverse card-info text-center">
   <div class="card-block">
     <blockquote class="card-blockquote">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. <a class="card-link">Integer</a> posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
     </blockquote>
   </div>
@@ -330,7 +330,7 @@ description: |
 <div class="card card-inverse card-warning text-center">
   <div class="card-block">
     <blockquote class="card-blockquote">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. <a class="card-link">Integer</a> posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
     </blockquote>
   </div>
@@ -338,7 +338,7 @@ description: |
 <div class="card card-inverse card-danger text-center">
   <div class="card-block">
     <blockquote class="card-blockquote">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. <a class="card-link">Integer</a> posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
     </blockquote>
   </div>
@@ -348,7 +348,7 @@ description: |
 <div class="card card-inverse card-primary text-center">
   <div class="card-block">
     <blockquote class="card-blockquote">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. <a class="card-link">Integer</a> posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
     </blockquote>
   </div>
@@ -356,7 +356,7 @@ description: |
 <div class="card card-inverse card-success text-center">
   <div class="card-block">
     <blockquote class="card-blockquote">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. <a class="card-link">Integer</a> posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
     </blockquote>
   </div>
@@ -364,7 +364,7 @@ description: |
 <div class="card card-inverse card-info text-center">
   <div class="card-block">
     <blockquote class="card-blockquote">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. <a class="card-link">Integer</a> posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
     </blockquote>
   </div>
@@ -372,7 +372,7 @@ description: |
 <div class="card card-inverse card-warning text-center">
   <div class="card-block">
     <blockquote class="card-blockquote">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. <a class="card-link">Integer</a> posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
     </blockquote>
   </div>
@@ -380,7 +380,7 @@ description: |
 <div class="card card-inverse card-danger text-center">
   <div class="card-block">
     <blockquote class="card-blockquote">
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. <a class="card-link">Integer</a> posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
     </blockquote>
   </div>

--- a/less/availity-cards.less
+++ b/less/availity-cards.less
@@ -109,21 +109,43 @@
   .card-footer {
     border-bottom: 1px solid rgba(255,255,255,.2);
   }
-  .card-header,
-  .card-footer,
-  .card-title,
-  .card-blockquote {
-    color: #fff;
-  }
-  .card-link,
-  .card-text,
-  .card-blockquote > footer {
-    color: rgba(255,255,255,.65);
-  }
-  .card-link {
-    &:hover,
-    &:focus {
+  // The warning background is too light to make effective use of the inverse colors.
+  &:not(.card-warning) {
+    .card-header,
+    .card-footer,
+    .card-title,
+    .card-blockquote {
       color: #fff;
+    }
+    .card-link,
+    .card-text,
+    .card-blockquote > footer {
+      color: rgba(255,255,255,.65);
+    }
+    .card-link {
+      &:hover,
+      &:focus {
+        color: #fff;
+      }
+    }
+  }
+  &.card-warning {
+    .card-header,
+    .card-footer,
+    .card-title,
+    .card-blockquote {
+      color: @gray;
+    }
+    .card-link,
+    .card-text,
+    .card-blockquote > footer {
+      color: rgba(0,0,0,.65);
+    }
+    .card-link {
+      &:hover,
+      &:focus {
+        color: @gray;
+      }
     }
   }
 }


### PR DESCRIPTION
Previously, the combination of card-inverse and card-warning displayed white text on a yellow background, rendering the text difficult to read.

This modification does not apply the standard card-inverse color styles to card-warning cards, but variations of the body standard (gray) instead.