### PR TITLE
correct disabled navs color

### DIFF
--- a/less/availity-navs.less
+++ b/less/availity-navs.less
@@ -40,6 +40,13 @@
         border-bottom: 3px solid @blue-darker;
       }
     }
+
+    &.disabled > a {
+      &:hover,
+      &:focus {
+        border-bottom-color: @disabled-text-color;
+      }
+    }
   }
 }
 

--- a/less/availity-variables.less
+++ b/less/availity-variables.less
@@ -349,7 +349,10 @@
 @button-box-shadow-inset: inset 0 1px 2px rgba(0,0,0,.1);
 @btn-link-disabled-color:        @disabled-text-color;
 
-//== Pills
+//== Navs
+@nav-disabled-link-color: @disabled-text-color;
+@nav-disabled-link-hover-color: @disabled-text-color;
+
 @nav-pills-active-link-hover-bg: @gray-lighter;
 
 //== Alerts and warnings


### PR DESCRIPTION
Disabled navs text was previously too light to read.

Before:
![image](https://cloud.githubusercontent.com/assets/902065/10009503/e8e8c778-60ab-11e5-9cbc-5095557199cb.png)
![image](https://cloud.githubusercontent.com/assets/902065/10009506/f4a7b998-60ab-11e5-83e5-efbebbc8b110.png)
![image](https://cloud.githubusercontent.com/assets/902065/10009508/02c939ac-60ac-11e5-9f3b-7fc1691db4ed.png)

After:
![image](https://cloud.githubusercontent.com/assets/902065/10009511/15ec2044-60ac-11e5-8fc4-9009fcafe5e2.png)
![image](https://cloud.githubusercontent.com/assets/902065/10009518/21df12da-60ac-11e5-8336-32e8bfdfbb10.png)
![image](https://cloud.githubusercontent.com/assets/902065/10009523/324f0bca-60ac-11e5-9a2b-60303b9a32a5.png)
