### PR TITLE
Fixed right sidebar to have a left border to be consistent with left bar

### DIFF
--- a/less/availity-layouts.less
+++ b/less/availity-layouts.less
@@ -7,7 +7,7 @@
   }
 
   &.right {
-   border-right: 1px solid darken(@gray-lighter, 5%);
+   border-left: 1px solid darken(@gray-lighter, 5%);
   }
 }
 


### PR DESCRIPTION
The left and right sidebars have a specific class for putting a border on the right side.  The only reason it seems that we make a distinction between the .right and .left classes is to control the location of this border.  However, both classes put it on the right.  This makes right sidebars have a border along the edge of the page, and nothing separating them from the main content.