### PR TITLE
feature/v2: Fix less references for npm-install/webpack

### DIFF
--- a/less/availity-external-libs.less
+++ b/less/availity-external-libs.less
@@ -1,7 +1,7 @@
-@datepicker-less-path: "../node_modules/bootstrap-datepicker/less";
-@select2-less-path: "../node_modules/select2";
-@select2-bootstap-less-path: "../node_modules/select2-bootstrap-theme";
-@awesome-bootstrap-checkbox-less-path: "../node_modules/awesome-bootstrap-checkbox";
+@datepicker-less-path: "~bootstrap-datepicker/less";
+@select2-less-path: "~select2";
+@select2-bootstap-less-path: "~select2-bootstrap-theme";
+@awesome-bootstrap-checkbox-less-path: "~awesome-bootstrap-checkbox";
 
 @import "@{datepicker-less-path}/datepicker3.less";
 @import (less) "@{select2-less-path}/dist/css/select2.css";

--- a/less/availity-type.less
+++ b/less/availity-type.less
@@ -1,6 +1,6 @@
 // HACK: Importing Bootstrap mixin explicitly because it is inaccessible
 // despite being imported in availity-bootstrap
-@import (reference) "../node_modules/bootstrap/less/mixins/text-overflow.less";
+@import (reference) "~bootstrap/less/mixins/text-overflow.less";
 
 h1, h2, h3, h4, h5, h6,
 .h1, .h2, .h3, .h4, .h5, .h6 {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
   "files": [
     "dist",
     "docs/less/**/*.less",
+    "docs/images",
     "fonts",
+    "images",
     "js/*.js",
     "less/**/*.less"
   ],

--- a/package.json
+++ b/package.json
@@ -110,8 +110,6 @@
     "raw-loader": "0.5.1",
     "require-dir": "^0.3.0",
     "sass-loader": "3.1.2",
-    "select2": "4.0.1",
-    "select2-bootstrap-theme": "0.1.0-beta.4",
     "semver": "^5.0.3",
     "shelljs": "0.6.0",
     "slug": "0.9.1",
@@ -134,6 +132,8 @@
   "dependencies": {
     "Yamm": "git+https://github.com/geedmo/yamm3.git#v1.1.0",
     "awesome-bootstrap-checkbox": "0.3.6",
-    "bootstrap": "3.3.6"
+    "bootstrap": "3.3.6",
+    "select2": "4.0.1",
+    "select2-bootstrap-theme": "0.1.0-beta.4"
   }
 }


### PR DESCRIPTION
When using availity-uikit@2.x, webpack fails on importing less files. This fixes Issues #132 and #130

