### PR TITLE
fix: remove form select background color

### DIFF
--- a/packages/uikit/scss/_forms.scss
+++ b/packages/uikit/scss/_forms.scss
@@ -14,10 +14,6 @@ label {
 
 }
 
-select.form-control {
-  background-color: $gray-lightest;
-}
-
 .custom-select {
   -webkit-appearance: none;
   width: auto;


### PR DESCRIPTION
Current background color looks nearly identical to the disabled background color, so I'm suggesting we remove this styling.