### PR TITLE
fix(uikit): fix incompatible unit

### DIFF
--- a/packages/uikit/scss/_variables.scss
+++ b/packages/uikit/scss/_variables.scss
@@ -559,7 +559,7 @@ $label-link-hover-color: #fff !default;
 $label-font-weight: bold !default;
 // Modals
 // Padding applied to the modal body
-$availity-modal-padding: 24px !default;
+$availity-modal-padding: 1.5rem !default;
 $modal-inner-padding: $availity-modal-padding;
 $modal-title-padding: 15px !default;
 $modal-title-line-height: $line-height !default;


### PR DESCRIPTION
Bootstrap defines `$modal-inner-padding` in `rem` units like so:

$modal-inner-padding:               1rem !default;

When we override that value with uikit, we were using `px` units, resulting in the following error:

```
Error in Module build failed (from ../../node_modules/sass-loader/dist/cjs.js):
SassError: Incompatible units: 'rem' and 'px'.
        on line 178 of node_modules/bootstrap/scss/_modal.scss
        from line 38 of node_modules/bootstrap/scss/bootstrap.scss
        from line 7 of node_modules/availity-uikit/scss/_bootstrap.scss
>>   padding: $modal-inner-padding - $modal-footer-margin-between / 2;
```

This PR changes that to use `rem` instead. I used https://nekocalc.com/px-to-rem-converter to convert `24px` to `1.5rem`. 
