### PR TITLE
feat(pagination): adding text-decoration, and font-weight for active/inactive buttons

### DIFF
--- a/packages/uikit/scss/_pagination.scss
+++ b/packages/uikit/scss/_pagination.scss
@@ -1,36 +1,17 @@
 .pagination {
   > .page-item > .page-link {
     font-weight: $availity-pagination-font-weight;
-    &:hover,
+    text-decoration: underline;
     &:focus {
       text-decoration: none;
     }
   }
-}
-
-.pagination {
-  > .page-item.active {
-    > .page-link {
-      text-decoration: none;
-      font-weight: bold;
-    }
+  > .page-item.disabled > .page-link {
+    text-decoration: none;
   }
-}
-
-.pagination {
-  > .page-item.disabled {
-    > .page-link {
-      text-decoration: none;
-    }
-  }
-}
-
-.pagination {
-  > .page-item {
-    > .page-link {
-      text-decoration: underline;
-    }
-  }
+  > .page-item.active > .page-link {
+    text-decoration: none;
+    font-weight: bold;  }
 }
 
 .pagination-container {

--- a/packages/uikit/scss/_pagination.scss
+++ b/packages/uikit/scss/_pagination.scss
@@ -3,7 +3,7 @@
     font-weight: $availity-pagination-font-weight;
     text-decoration: underline;
     &:hover {
-      color: black;
+      color: $text-darkest;
     }
   }
   > .page-item.disabled > .page-link {
@@ -14,7 +14,7 @@
     font-weight: bold;
     &:hover,
     &:focus {
-      color: white;
+      color: $white;
     }
   }
 
@@ -48,10 +48,11 @@
 	  border-width: 0;
 
     &:hover {
-      color: black;
+      color: $text-darkest;
     }
     &:focus {
-      background-color: $pagination-hover-bg;
+      color: $text-darkest;
+
     }
   }
 
@@ -60,7 +61,7 @@
     &:hover,
     &:focus {
       background-color: $pagination-active-bg;
-      color: white;
+      color: $white;
     }
   }
 

--- a/packages/uikit/scss/_pagination.scss
+++ b/packages/uikit/scss/_pagination.scss
@@ -8,6 +8,31 @@
   }
 }
 
+.pagination {
+  > .page-item.active {
+    > .page-link {
+      text-decoration: none;
+      font-weight: bold;
+    }
+  }
+}
+
+.pagination {
+  > .page-item.disabled {
+    > .page-link {
+      text-decoration: none;
+    }
+  }
+}
+
+.pagination {
+  > .page-item {
+    > .page-link {
+      text-decoration: underline;
+    }
+  }
+}
+
 .pagination-container {
   @include clearfix();
 

--- a/packages/uikit/scss/_pagination.scss
+++ b/packages/uikit/scss/_pagination.scss
@@ -2,8 +2,8 @@
   > .page-item > .page-link {
     font-weight: $availity-pagination-font-weight;
     text-decoration: underline;
-    &:focus {
-      text-decoration: none;
+    &:hover {
+      color: black;
     }
   }
   > .page-item.disabled > .page-link {
@@ -11,7 +11,13 @@
   }
   > .page-item.active > .page-link {
     text-decoration: none;
-    font-weight: bold;  }
+    font-weight: bold;
+    &:hover,
+    &:focus {
+      color: white;
+    }
+  }
+
 }
 
 .pagination-container {
@@ -41,7 +47,9 @@
 	  background-color: transparent;
 	  border-width: 0;
 
-    &:hover,
+    &:hover {
+      color: black;
+    }
     &:focus {
       background-color: $pagination-hover-bg;
     }
@@ -52,6 +60,7 @@
     &:hover,
     &:focus {
       background-color: $pagination-active-bg;
+      color: white;
     }
   }
 


### PR DESCRIPTION
This PR aims to better distinguish between active and inactive buttons for pagination components. Adding in bold font-weight for the active button and underlining the inactive buttons to help for accessibility. 

![2021-08-04_18-43-25 (1)](https://user-images.githubusercontent.com/24685932/128265117-32697aa8-40c2-4714-9759-a019b87f8b24.gif)
