### PR TITLE
feat(breadcrumbs): making links always underlined for 508 compliance

### DIFF
--- a/packages/uikit/scss/_breadcrumbs.scss
+++ b/packages/uikit/scss/_breadcrumbs.scss
@@ -3,6 +3,10 @@
     padding-left: 0;
     .breadcrumb-item {
         font-weight: $availity-breadcrumb-font-weight;
+        text-decoration: underline;
+    &:hover {
+      color: $text-darkest;
+    }
         +.breadcrumb-item::before {
             font-family: $availity-icon-font;
             font-weight: $availity-breadcrumb-font-weight;
@@ -11,6 +15,7 @@
     }
     >.active {
         font-weight: $availity-breadcrumb-font-weight-active;
+        text-decoration: none;
     }
 }
 


### PR DESCRIPTION
Blue cannot be the only indicator for links on a page. All links should be default underlined to be 508 compliant.

"Ensure color is not the sole means of communicating information
Blue link elements use color as the only visual means to convey they are links that can be interacted with.
Provide an underline text decoration in the link's default state, with an underline on focus and hover.

![Screen Shot 2021-09-20 at 11 20 01 AM](https://user-images.githubusercontent.com/16522636/134028842-04d347d1-c9bb-45a5-87d1-bf39797ec055.png)
"