### PR TITLE
fix(uikit): revert btn focus fix

### DIFF
--- a/packages/uikit/package.json
+++ b/packages/uikit/package.json
@@ -47,5 +47,5 @@
     "framework",
     "web"
   ],
-  "gitHead": "aade0109d5b7857eddf170afcbfb0e1f400c239e"
+  "gitHead": "123b2185c1739d6325782595d1869ec115910995"
 }

--- a/packages/uikit/scss/bootstrap/scss/_reboot.scss
+++ b/packages/uikit/scss/bootstrap/scss/_reboot.scss
@@ -312,8 +312,19 @@ button {
 // should be doing this automatically, but seems to currently be
 // confused and applies its very visible two-tone outline anyway.
 
-button:focus:not(:focus-visible) {
-  outline: 0;
+// button:focus:not(:focus-visible) {
+//   outline: 0;
+// }
+
+// The commented out section above is the 'new' fix. It conflicts
+// with MUI styling so we are using the old fix instead.
+// Work around a Firefox/IE bug where the transparent `button` background
+// results in a loss of the default `button` focus styles.
+//
+// Credit: https://github.com/suitcss/base/
+button:focus {
+  outline: 1px dotted;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 input,


### PR DESCRIPTION
There was a 'fix' in bootstrap 4.6.2 that caused a collision with styles from MUI. We are reverting it to what was being used before it as we haven't seen any issues with it on the portal so far.